### PR TITLE
Added yt-dlp installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 - `yt-dlp`
 
 ###### Install requirements for Debian-based distros
+
+> Debian Bullseye (Stable) does not have yt-dlp in their repository.
+
 ```
 sudo apt install curl ffmpeg python3 yt-dlp
 ```

--- a/yt-dlp_installer.sh
+++ b/yt-dlp_installer.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp
+sudo chmod a+rx /usr/local/bin/yt-dlp  # Make executable


### PR DESCRIPTION
A script like that is required for some distros (e.g. Debian Bullseye (Stable) that I use) because they don't have `yt-dlp` in their repository. It needs `curl` to download `yt-dlp`.